### PR TITLE
Update instructions for uploading a local file

### DIFF
--- a/powerapps-docs/controls/control-image.md
+++ b/powerapps-docs/controls/control-image.md
@@ -107,7 +107,7 @@ If you add one or more **Image** controls to your app, you can show individual i
 
 ## Examples
 ### Show an image from a local file
-1. On the **Content** tab, click or tap **Media**, and then click or tap **Browse**.
+1. On the **File** tab, click or tap **Media**, and then click or tap **Browse**.
 2. Click or tap the image file that you want to add, click or tap **Open**, and then press Esc to return to the default workspace.
 3. Add an **Image** control, and set its **[Items](properties-core.md)** property to the name of the file that you added.
 


### PR DESCRIPTION
This change updates the verbiage from "Content" tab (which doesn't seem to exist anymore) to the "File" Tab, where Media seems to live now.