### PR TITLE
Added link to Connectors link that lists Premium Connectors

### DIFF
--- a/powerapps-docs/maker/canvas-apps/connections-list.md
+++ b/powerapps-docs/maker/canvas-apps/connections-list.md
@@ -53,7 +53,7 @@ For more information about how to to customize your formula for custom updates, 
 
 ## Popular connectors
 
-This table has links to more information about our most popular connectors. For a complete list of connectors, see [All connectors](#all-connectors).
+This table has links to more information about our most popular connectors. For a complete list of connectors, see [All connectors](https://flow.microsoft.com/en-us/connectors/).
 
 | &nbsp; | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
The current link does not go anywhere and customers are looking for a list of the Premium Connectors.  The Flow site provides this list, but no list exists in the PowerApps domain.