### PR TITLE
Clarifying relational operators delegation in SPO

### DIFF
--- a/powerapps-docs/maker/canvas-apps/delegation-list.md
+++ b/powerapps-docs/maker/canvas-apps/delegation-list.md
@@ -65,9 +65,10 @@ This list of data sources and delegable functions and predicates will be updated
 | TrimEnds |No |No |Yes |No |No |
 | Len |No |No |Yes |No |No |
 | +, - |No |No |Yes |No |No |
-| <, <=, =, <>, >, >= |Yes |Yes |Yes |Yes |Yes |
-| And (&&), Or (&#124;&#124;), Not (!) |Yes<sup>2</sup> |Yes (except Not(!)) |Yes |Yes |Yes |
+| <, <=, =, <>, >, >= |Yes |Yes<sup>2</sup> |Yes |Yes |Yes |
+| And (&&), Or (&#124;&#124;), Not (!) |Yes<sup>3</sup> |Yes (except Not(!)) |Yes |Yes |Yes |
 | in |No |No |Yes |No |Yes |
 | StartsWith |No |Yes |No |No |No |
 
-<sup>2</sup>For operators only. And/Or/Not function not delegated.
+<sup>2</sup>For numeric columns, all operators can be delegated. For ID columns, only the '=' can be delegated. There's no delegation for date columns.<br/>
+<sup>3</sup>For operators only. And/Or/Not function not delegated.

--- a/powerapps-docs/maker/canvas-apps/delegation-list.md
+++ b/powerapps-docs/maker/canvas-apps/delegation-list.md
@@ -70,5 +70,5 @@ This list of data sources and delegable functions and predicates will be updated
 | in |No |No |Yes |No |Yes |
 | StartsWith |No |Yes |No |No |No |
 
-<sup>2</sup>For numeric columns, all operators can be delegated. For ID columns, only the '=' can be delegated. There's no delegation for date columns.<br/>
+<sup>2</sup>For numeric columns, all operators can be delegated. For ID columns, only the '=' can be delegated. Date columns can't be delegated.<br/>
 <sup>3</sup>For operators only. And/Or/Not function not delegated.


### PR DESCRIPTION
Relational operations are delegated in SharePoint differently depending on the column type to which the operators refer. This edit clarifies that.