### PR TITLE
Correct gridContext `More information` link target

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/understand-clientapi-object-model.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/understand-clientapi-object-model.md
@@ -37,7 +37,7 @@ At the root of the Client API object model are the following contexts and the Xr
 |--|--|
 |**executionContext**|Represents the execution context for an event in model-driven apps forms and grids.<br/>More information: [Client API execution context](clientapi-execution-context.md)|
 |**formContext** |Provides a reference to a form or an item on the form against which the current code executes. To get the **formContext** object, use the **executionContext**.[getFormContext](reference/executioncontext/getFormContext.md) method.<br/>More information: [Client API form context](clientapi-form-context.md)|
-|**gridContext** |Provides a reference to a grid or a subgrid on a form against which the current code executes.<br/>More information: [Client API grid context](clientapi-form-context.md)|
+|**gridContext** |Provides a reference to a grid or a subgrid on a form against which the current code executes.<br/>More information: [Client API grid context](clientapi-grid-context.md)|
 |**Xrm**| Provides a global object for performing operations that do not directly impact the data and UI in forms, grids, subgrids, controls, or attributes. For example, navigate forms, create and manage records using Web API.<br/>More information: [Client API Xrm object](clientapi-xrm.md)|
 
 ### Related topics


### PR DESCRIPTION
The `More information` link for `gridContext` is targeting the `formContext` documentation. Corrected the link to target the `gridContext` page instead.