### PR TITLE
 Upper case API as per interface

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/includes/webapi-description.md
+++ b/powerapps-docs/developer/component-framework/reference/includes/webapi-description.md
@@ -1,5 +1,5 @@
 ---
-title: WebApi | Microsoft Docs
+title: WebAPI | Microsoft Docs
 description: 
 keywords:
 ms.author: nabuthuk
@@ -14,4 +14,4 @@ applies_to:
   - "Dynamics 365 Version 9.x"
 ms.assetid: e4a8b275-0db1-4025-aa97-c9e55b84d6c6
 ---
-The interface for `context.webApi`
+The interface for `context.webAPI`


### PR DESCRIPTION
Change context.webApi to context.webAPI to bring inline with the actual implementation of the interface.