### PR TITLE
Improve comments in the example

### DIFF
--- a/powerapps-docs/developer/common-data-service/org-service/execute-multiple-requests.md
+++ b/powerapps-docs/developer/common-data-service/org-service/execute-multiple-requests.md
@@ -127,7 +127,7 @@ Fortunately, there is another method that you can use. When the number of reques
 ```csharp
 catch (FaultException<OrganizationServiceFault> fault)
 {
-    // Check if the maximum batch size has been exceeded. The maximum batch size is only included in the fault if it
+    // Check if the maximum batch size has been exceeded. The maximum batch size is only included in the fault if
     // the input request collection count exceeds the maximum batch size.
     if (fault.Detail.ErrorDetails.Contains("MaxBatchSize"))
     {


### PR DESCRIPTION
Removed an extra word from the comments in the maximum batch size fault example.