### PR TITLE
Fixed casing on pac command

### DIFF
--- a/powerapps-docs/developer/component-framework/import-custom-controls.md
+++ b/powerapps-docs/developer/component-framework/import-custom-controls.md
@@ -68,7 +68,7 @@ You can deploy the code components directly from the Power Apps CLI by connectin
 3. To switch between the previously created authentication profiles, use the command: 
    
    ```CLI
-    Pac auth select --index <index of the active profile>
+    pac auth select --index <index of the active profile>
     ``` 
 
 4. To get the basic information about the environment, use the following command. The connection will be made using the default authentication profile. 


### PR DESCRIPTION
Fixed casing on one of the pac command. "p" should be small