### PR TITLE
setControlState(mode) => setFullScreen(value)

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/mode/setfullscreen.md
+++ b/powerapps-docs/developer/component-framework/reference/mode/setfullscreen.md
@@ -22,7 +22,7 @@ ms.assetid: 1faf3e79-969e-4c1e-ac01-8e2155c609fa
 
 ## Syntax
 
-`context.mode.setControlState(mode);`
+`context.mode.setFullScreen(value);`
 
 ## Available for 
 


### PR DESCRIPTION
`setControlState(mode)` should read `setFullScreen(value)`.

context.mode.setFullScreen(value) is the correct way to make a PCF enter/exit full screen mode.