### PR TITLE
#1258: Mentioned behavior when parameter is missing to `formContext.getControl`

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/controls/getControl.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/controls/getControl.md
@@ -28,7 +28,9 @@ The **formContext.getControl(arg)** method is a shortcut method to access **form
 
 ## Parameter
 
-**arg**: Optional. You can access a control on a form by passing an argument as either the **name** or the **index valu**e of the control on a form. For example: `formContext.getControl("firstname")` or `formContext.getControl(0)`
+**arg**: Optional. You can access a control on a form by passing an argument as either the **name** or the **index value** of the control on a form. For example: `formContext.getControl("firstname")` or `formContext.getControl(0)`.
+
+When it is not provided, it returns an array of all controls on the form.
 
 
 ## Return Value

--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/controls/getControl.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/controls/getControl.md
@@ -30,7 +30,7 @@ The **formContext.getControl(arg)** method is a shortcut method to access **form
 
 **arg**: Optional. You can access a control on a form by passing an argument as either the **name** or the **index value** of the control on a form. For example: `formContext.getControl("firstname")` or `formContext.getControl(0)`.
 
-When it is not provided, it returns an array of all controls on the form.
+When the `arg` value is not provided, it returns an array of all the controls on the form.
 
 
 ## Return Value


### PR DESCRIPTION
Small update to mention the default behavior for this function with no parameters