### PR TITLE
Update msbuild command options

### DIFF
--- a/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
+++ b/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
@@ -369,7 +369,7 @@ Follow these steps to create and import a [solution](https://docs.microsoft.com/
     ```
     > [!TIP]
     > You will be hit with the error: *Do not use the `eval` function or its functional equivalents*, when you build the solution file using the `msbuild` command and import it into Common Data Service and run the solution checker.
-    > Re build the solution file using the command `msbuild/property:configuration:Release` and reimport the solution into Common Data Service and run the solution checker.
+    > Re build the solution file using the command `msbuild/property:configuration=Release` and reimport the solution into Common Data Service and run the solution checker.
       
     > [!NOTE]
     > Make sure that **NuGet targets & Build Tasks** is checked. To enable it:


### PR DESCRIPTION
Correct the syntax of msbuild command to build the release version. The correct format of property switch is /propery:<Property Name>=<Property Value>