### PR TITLE
Attachment downloads blocked by version 83 of Chrome and new Edge 

### DIFF
--- a/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
+++ b/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
@@ -18,6 +18,13 @@ search.app:
 
 This article lists some common issues that you might encounter while using Power Apps. Where applicable, workarounds are provided.
 
+
+1. **Problems downloading attachments in SharePoint custom forms** (May 21, 2020)
+   When using the attachment control to download an attachment the click will have no response using Chrome 83 and Microsoft Edge 83. To work around this issue change to use the default SharePoint form, or use another browser. The team is actively working to fix this issue.
+   
+1. **Problems downloading attachments in embedded Power Apps** (May 21, 2020)
+  When using the attachment control to download an attachment the click will have no response, when using Chrome 83 and Microsoft Edge 83. To work around use another browser. The team is actively working to fix this issue.
+  
 1. **Camera images when imported via Edge are flipped** (January 20, 2020)
 
     When using the camera and the Edge browser, the image may be flipped.  This is due to an Edge defect.  To mitigate this issue, please use the new Edge Chromium or a different browser.

--- a/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
+++ b/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
@@ -20,10 +20,10 @@ This article lists some common issues that you might encounter while using Power
 
 
 1. **Problems downloading attachments in SharePoint custom forms** (May 22, 2020)
-   When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83. As a workaround, change to use the default SharePoint form or use another browser. The team is actively working to fix this issue.
+   When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83 browser. As a workaround, change to use the default SharePoint form or use another browser. The team is actively working to fix this issue.
    
 1. **Problems downloading attachments in embedded Power Apps** (May 22, 2020)
-  When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83. As a workaround, use another browser. The team is actively working to fix this issue.
+  When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83 browser. As a workaround, use another browser. The team is actively working to fix this issue.
   
 1. **Camera images when imported via Edge are flipped** (January 20, 2020)
 

--- a/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
+++ b/powerapps-docs/maker/canvas-apps/common-issues-and-resolutions.md
@@ -7,7 +7,7 @@ ms.service: powerapps
 ms.topic: conceptual
 ms.custom: canvas
 ms.reviewer: 
-ms.date: 08/21/2019
+ms.date: 05/22/2020
 ms.author: kvivek
 search.audienceType: 
   - maker
@@ -19,15 +19,15 @@ search.app:
 This article lists some common issues that you might encounter while using Power Apps. Where applicable, workarounds are provided.
 
 
-1. **Problems downloading attachments in SharePoint custom forms** (May 21, 2020)
-   When using the attachment control to download an attachment the click will have no response using Chrome 83 and Microsoft Edge 83. To work around this issue change to use the default SharePoint form, or use another browser. The team is actively working to fix this issue.
+1. **Problems downloading attachments in SharePoint custom forms** (May 22, 2020)
+   When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83. As a workaround, change to use the default SharePoint form or use another browser. The team is actively working to fix this issue.
    
-1. **Problems downloading attachments in embedded Power Apps** (May 21, 2020)
-  When using the attachment control to download an attachment the click will have no response, when using Chrome 83 and Microsoft Edge 83. To work around use another browser. The team is actively working to fix this issue.
+1. **Problems downloading attachments in embedded Power Apps** (May 22, 2020)
+  When using the attachment control to download an attachment, the click won't have any response when using Google Chrome version 83 or the new Microsoft Edge version 83. As a workaround, use another browser. The team is actively working to fix this issue.
   
 1. **Camera images when imported via Edge are flipped** (January 20, 2020)
 
-    When using the camera and the Edge browser, the image may be flipped.  This is due to an Edge defect.  To mitigate this issue, please use the new Edge Chromium or a different browser.
+    When using the camera and the legacy Microsoft Edge browser, the image may be flipped. This is due to legacy Edge browser defect. To mitigate this issue, use the new Microsoft Edge or a different browser.
     
 1. **Camera images do not contain meta-data information** (January 20, 2020)
 


### PR DESCRIPTION
With build 83 of chromium used in both chrome and edge based on chrome the attachment control fails when embedded in SharePoint forms, SharePoint Webparts, Canvas in Model and Power BI.