### PR TITLE
Fix the Content-Range header

### DIFF
--- a/powerapps-docs/developer/common-data-service/file-attributes.md
+++ b/powerapps-docs/developer/common-data-service/file-attributes.md
@@ -2,7 +2,7 @@
 title: "File attributes (Common Data Service) | Microsoft Docs" # Intent and product brand in a unique string of 43-59 chars including spaces
 description: "Learn about File attributes that store file data within the application, supporting attributes, retrieving data, and uploading file data." # 115-145 characters including spaces. This abstract displays in the search result.
 ms.custom: ""
-ms.date: 05/08/2020
+ms.date: 06/17/2020
 ms.reviewer: "pehecke"
 ms.service: powerapps
 ms.topic: "article"
@@ -63,7 +63,7 @@ Messages such as <xref:Microsoft.Xrm.Sdk.Messages.RetrieveRequest> and <xref:Mic
 ```http
 GET [Organization URI]/api/data/v9.1/accounts(id)/myfileattribute/$value
 Headers:
-Range: 0-1023/8192
+Range: bytes=0-1023/8192
 ```
 
 **Response**

--- a/powerapps-docs/developer/common-data-service/file-attributes.md
+++ b/powerapps-docs/developer/common-data-service/file-attributes.md
@@ -166,7 +166,7 @@ Location: api/data/v9.1/accounts(id)/myfileattribute?FileContinuationToken
 PATCH [Organization URI]/api/data/v9.1/accounts(id)/myfileattribute?FileContinuationToken 
 
 Headers: 
-Content-Range: 0-4095/8192 
+Content-Range: bytes 0-4095/8192 
 Content-Type: application/octet-stream
 x-ms-file-name: sample.png
 


### PR DESCRIPTION
When providing the Content-Range header during upload, it actually has to be prefixed with "bytes ", otherwise CDS will return code 416.