### PR TITLE
Fixed the description of the And function

### DIFF
--- a/powerapps-docs/maker/canvas-apps/functions/function-logicals.md
+++ b/powerapps-docs/maker/canvas-apps/functions/function-logicals.md
@@ -21,7 +21,7 @@ Boolean logic functions, commonly used to manipulate the results of comparisons 
 
 ## Description
 
-The **And** function returns **true** if all of its arguments are **true**.
+The **And** function returns **true** if all arguments do not contain **false**.
 
 The **Or** function returns **true** if any of its arguments are **true**.
 


### PR DESCRIPTION
The And function is also available with exactly no arguments, in which case In that case, the And function returns true, so the previous description is incorrect.