### PR TITLE
Example for Enum added

### DIFF
--- a/powerapps-docs/developer/component-framework/manifest-schema-reference/type.md
+++ b/powerapps-docs/developer/component-framework/manifest-schema-reference/type.md
@@ -37,8 +37,8 @@ This element contains a `string` with one of the following values:
 
 ```XML
 <property name="YesNo" display-name-key="YesNo_Display_Key" description-key="YesNo_Desc_Key" of-type="Enum" usage="input" required="false">
-      <value name="Yes" display-name-key="Yes" >0</value>
-      <value name="No" display-name-key="No" >1</value>
+      <value name="Yes" display-name-key="Yes">0</value>
+      <value name="No" display-name-key="No">1</value>
 </property>
 ```
 

--- a/powerapps-docs/developer/component-framework/manifest-schema-reference/type.md
+++ b/powerapps-docs/developer/component-framework/manifest-schema-reference/type.md
@@ -33,15 +33,13 @@ This element contains a `string` with one of the following values:
 
 [!INCLUDE [type-table](includes/type-table.md)]
 
-### Example
+### Example for Enum type
 
 ```XML
-<type-group name="numbers">
-      <type>Whole.None</type>
-      <type>Currency</type>
-      <type>FP</type>
-      <type>Decimal</type>
-    </type-group>
+<property name="YesNo" display-name-key="YesNo_Display_Key" description-key="YesNo_Desc_Key" of-type="Enum" usage="input" required="false">
+      <value name="Yes" display-name-key="Yes" >0</value>
+      <value name="No" display-name-key="No" >1</value>
+</property>
 ```
 
 ### Related topics


### PR DESCRIPTION
Example of type-group doesn't suit here instead replaced it with example for Enum because lot of people don't know how to use it.