### PR TITLE
Update oauth-implicit-grant-flow.md

### DIFF
--- a/powerapps-docs/maker/portals/oauth-implicit-grant-flow.md
+++ b/powerapps-docs/maker/portals/oauth-implicit-grant-flow.md
@@ -20,7 +20,6 @@ OAuth 2.0 implicit grant flow supports endpoints that a client can call to get a
 > Power Apps portals supports following OpenIdConnect flows and response types:
 >
 > - **Implicit Flow** with response types *id_token* or *id_token token*.
-> - **Hybrid Flow** with response type *code id_token*.
 >
 > **Authorization Code Flow** with response type *code* is **not supported**. For more information, read [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html#Authentication) documentation for authentication.
 
@@ -41,7 +40,7 @@ The URL for authorize endpoint is: `<portal_url>/_services/auth/authorize`. The 
 
 The authorize endpoint returns the following values in the response URL as a fragment:
 
-- **token**: Token is returned as a JSON Web Token (JWT) digitally signed by the portal’s private key.
+- **token**: Access token is returned as a JSON Web Token (JWT) digitally signed by the portal’s private key.
 - **state**: If a state parameter is included in the request, the same value should appear in the response. The app should verify that the state values in the request and response are identical.
 - **expires_in**: The length of time that the access token is valid (in seconds).
 


### PR DESCRIPTION
Removed Hybrid flow, because I tired /_services/auth/authorize?client_id=[clientid]&redirect_uri=[redirecturl]&response_type=code%20id_token and it returned error which means it doesn't support hybrid flow for this function. 
{"ErrorId":"PortalSTS0007","ErrorMessage":"Value provided for the response type parameter is not a supported value. Please check the value and try again.","Timestamp":"7/29/2020 11:57:31 AM","CorrelationId":"23c83ef5-bea2-4a8c-b864-328523d0248e"}

Also, in the token return, added a clarification that the token returned is an access token (based on OAuth standard and Microsoft convention of access token), this can make this statement a bit clearer.