### PR TITLE
Changing owner for SSS PM

### DIFF
--- a/powerapps-docs/developer/common-data-service/configure-exchange-folder-level-tracking-rules.md
+++ b/powerapps-docs/developer/common-data-service/configure-exchange-folder-level-tracking-rules.md
@@ -6,7 +6,7 @@ ms.date: 10/31/2018
 ms.reviewer: "pehecke"
 ms.service: powerapps
 ms.topic: "article"
-author: "mayadumesh" # GitHub ID
+author: "revchauhan" # GitHub ID
 ms.author: "jdaly" # MSFT alias of Microsoft employees only
 manager: "ryjones" # MSFT alias of manager or PM counterpart
 search.audienceType: 


### PR DESCRIPTION
I took new responsibility of SSS PM and I would like to propose this change so that users are directed to me.