### PR TITLE
Update implementing-controls-using-typescript.md

### DIFF
--- a/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
+++ b/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
@@ -168,10 +168,7 @@ export class TSLinearInputComponent
     this._value = context.parameters.sliderValue.raw
       ? context.parameters.sliderValue.raw
       : 0;
-    this.inputElement.value =
-      context.parameters.sliderValue.formatted
-        ? context.parameters.sliderValue.formatted
-        : "0";
+    this.inputElement.value = this._value.toString();
     
     this.labelElement.innerHTML = context.parameters.sliderValue.formatted
       ? context.parameters.sliderValue.formatted
@@ -199,11 +196,7 @@ export class TSLinearInputComponent
       ? context.parameters.sliderValue.raw
       : 0;
     this._context = context;
-    this.inputElement.value =
-     
-      context.parameters.sliderValue.formatted
-        ? context.parameters.sliderValue.formatted
-        : "";
+    this.inputElement.value = this._value.toString();
     
     this.labelElement.innerHTML = context.parameters.sliderValue.formatted
       ? context.parameters.sliderValue.formatted


### PR DESCRIPTION
There is problem with the operation of the slider when the value is formatted. The range slider value should be set to the raw value converted to a string, not the formatted value. When you set the slider to 1000 it tries to use "1,000" which is not a valid float, and it behave erratically.

[If the value is set to something which can't be converted into a valid floating-point number, validation fails because the input is suffering from a bad input.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range)

[If parseFloat encounters a character other than a plus sign (+), minus sign (- U+002D HYPHEN-MINUS), numeral (0–9), decimal point (.), or exponent (e or E), it returns the value up to that character, ignoring the invalid character and characters following it.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat)