### PR TITLE
Update getoutputs-description.md

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/control/includes/getoutputs-description.md
+++ b/powerapps-docs/developer/component-framework/reference/control/includes/getoutputs-description.md
@@ -15,4 +15,4 @@ applies_to:
 ms.assetid: 06007e6e-7c82-4842-9584-75c5c5782c4d
 ---
 
-It is called by the framework prior to a component receiving the new data. Returns an object based on nomenclature defined in manifest, expecting objects[s] for the property marked as `bound` or `output`.
+It is called by the framework prior to a component receiving the new data. Returns an object based on nomenclature defined in manifest, expecting objects[s] for the property marked as `bound`.


### PR DESCRIPTION
usage has only one option 'bound'. The text 'output' is causing confusion as to what exactly does it corresponds.