### PR TITLE
Fix typo in PCF dataset paging api documentation

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/paging.md
+++ b/powerapps-docs/developer/component-framework/reference/paging.md
@@ -31,7 +31,7 @@ Total number of results on the server for the current query.
 
 ### hasNextPage
 
-Whether the result set can be paged backwards.
+Whether the result set can be paged forwards.
 
 **Type**: `boolean`
 


### PR DESCRIPTION
This should be forwards rather than backwards