### PR TITLE
Update EnvironmentVariables.md

### DIFF
--- a/powerapps-docs/maker/data-platform/EnvironmentVariables.md
+++ b/powerapps-docs/maker/data-platform/EnvironmentVariables.md
@@ -131,6 +131,7 @@ The `environmentvariabledefinition` table is [user or team owned](/powerapps/mak
 - When editing a cloud flow, the environment variables are shown in the dynamic content selector under a heading of **Parameters** but will be under a heading of **Environment Variables** in the near future. 
 - When editing a cloud flow, the environment variables shown in the dynamic content selector are unfiltered, but will be filtered by data type in the future. 
 - When editing a cloud flow, if an environment variable is added in another browser tab, the flow needs to be reopened in the flow designer to refresh the dynamic content selector.
+- When editing a cloud flow, an environment variable with a label of **$authentication** might show up that was not defined in the environment. This issue is being fixed in the near future.
  
 ## Frequently asked questions
 

--- a/powerapps-docs/maker/data-platform/EnvironmentVariables.md
+++ b/powerapps-docs/maker/data-platform/EnvironmentVariables.md
@@ -131,7 +131,7 @@ The `environmentvariabledefinition` table is [user or team owned](/powerapps/mak
 - When editing a cloud flow, the environment variables are shown in the dynamic content selector under a heading of **Parameters** but will be under a heading of **Environment Variables** in the near future. 
 - When editing a cloud flow, the environment variables shown in the dynamic content selector are unfiltered, but will be filtered by data type in the future. 
 - When editing a cloud flow, if an environment variable is added in another browser tab, the flow needs to be reopened in the flow designer to refresh the dynamic content selector.
-- When editing a cloud flow, an environment variable with a label of **$authentication** might show up that was not defined in the environment. This issue is being fixed in the near future.
+- When editing a cloud flow, an environment variable with a label of **$authentication** might show up that was not defined in the environment. 
  
 ## Frequently asked questions
 


### PR DESCRIPTION
Added documentation note about a high visibility issue: "an environment variable with a label of **$authentication** might show up that was not defined in the environment...". I'll update the docs in 4 weeks to remove this and the "**Parameters**" limitation once those fixes are in production.