### PR TITLE
Correction in non-delegable and delegable [performance-tips.md]

### DIFF
--- a/powerapps-docs/maker/canvas-apps/performance-tips.md
+++ b/powerapps-docs/maker/canvas-apps/performance-tips.md
@@ -99,7 +99,7 @@ Where possible, use functions that delegate data processing to the data source i
 > [!TIP]
 > To learn about delegable functions supported by specific connectors, go to the [connector documentation](/connectors/).
 
-For an example of delegable functions, consider an ID column defined as the **Number** data type in a SharePoint list. Formulas in the following example will return the results as expected. However, the first formula is non-delegable while the second is delegable.
+For an example of delegable functions, consider an ID column defined as the **Number** data type in a SharePoint list. Formulas in the following example will return the results as expected. However, the first formula is delegable while the second is non-delegable.
 
 | Formula                                           | Delegable? |
 |---------------------------------------------------|------------|


### PR DESCRIPTION
Changes in statement  from "However, the first formula is non-delegable while the second is delegable." to "However, the first formula is delegable while the second is non-delegable." as per formula described in table.