### PR TITLE
Updated limitations of control-power-bi-tile.md

### DIFF
--- a/powerapps-docs/maker/canvas-apps/controls/control-power-bi-tile.md
+++ b/powerapps-docs/maker/canvas-apps/controls/control-power-bi-tile.md
@@ -58,6 +58,7 @@ The parameter will filter a value in the dataset of the report where the tile or
 - Only the `eq` operator is supported.
 - Field type must be string.
 - Filtering is only available on pinned visualization tiles. It's not supported for pinned reports.
+- R and Python script visuals cannot be filtered.
 
 You can use computed fields in the Power BI report to convert other value types to string or combines multiple fields into one.
 


### PR DESCRIPTION
Added the note that R and Python script visuals cannot be filtered, as advised by Power BI in [this IcM](https://portal.microsofticm.com/imp/v3/incidents/details/239644450/home).