### PR TITLE
Update execute-multiple-requests.md

### DIFF
--- a/powerapps-docs/developer/data-platform/org-service/execute-multiple-requests.md
+++ b/powerapps-docs/developer/data-platform/org-service/execute-multiple-requests.md
@@ -37,7 +37,7 @@ Custom code in the form of plug-ins and custom workflow activities can even exec
 ```csharp
 
 // Create an ExecuteMultipleRequest object.
-requestWithResults = new ExecuteMultipleRequest()
+ExecuteMultipleRequest requestWithResults = new ExecuteMultipleRequest()
 {
     // Assign settings that define execution behavior: continue on error, return responses. 
     Settings = new ExecuteMultipleSettings()


### PR DESCRIPTION
Should either have `var` or type declaration, so that the sample is valid by itself.