### PR TITLE
More clarification on setting the Photo property

### DIFF
--- a/powerapps-docs/maker/canvas-apps/controls/control-camera.md
+++ b/powerapps-docs/maker/canvas-apps/controls/control-camera.md
@@ -27,7 +27,7 @@ A control that enables users to take pictures using the camera on a device.
 
 Use the **Camera** control to capture pictures with a device's camera. The device must have a camera and the user must authorize the app to use the camera.
 
-The most recently captured picture is available through the **Photo** property. With this property, the images can be:
+The most recently captured picture is available through the **Photo** property. This property is set when the user takes a picture by tapping or selecting the camera control. With this property, the images can be:
 
 - **Viewed with the Image control.** Use the [Image](control-image.md) control to view the captured image. For more information, see the [examples](#examples).  
 - **Temporarily put in a variable or a collection.**  Use the [Set](../functions/function-set.md) or [Collect](../functions/function-clear-collect-clearcollect.md) functions to store images in a variable or a collection.  Use caution when using multiple images in a collection at the same time consuming device's limited memory. Use the [SaveData](../functions/function-savedata-loaddata.md) and [LoadData](../functions/function-savedata-loaddata.md) functions to move images to the local storage on the device and for [offline scenarios](../offline-apps.md).


### PR DESCRIPTION
The **Photo** property is only set when the camera control is tapped or selected. Adding this to clarify as this is something that caused me wasted time trying to work out why I couldn't get an image when using a button, and has caused a number of questions across the internet.