### PR TITLE
Fixing incorrect upload command syntax

### DIFF
--- a/powerapps-docs/maker/portals/power-apps-cli-tutorial.md
+++ b/powerapps-docs/maker/portals/power-apps-cli-tutorial.md
@@ -113,7 +113,7 @@ directly in Visual Studio Code.
 
 After making the required changes, upload them using the following command:
 
-`pac paportal --path [Folder-location]`
+`pac paportal upload --path [Folder-location]`
 
 **Example**
 


### PR DESCRIPTION
Updated the `pac paportal update` command, which was missing the `update` operation.