### PR TITLE
Adding note about the Default property

### DIFF
--- a/powerapps-docs/maker/canvas-apps/controls/control-combo-box.md
+++ b/powerapps-docs/maker/canvas-apps/controls/control-combo-box.md
@@ -41,6 +41,9 @@ To use **Combo box** as a people picker, choose the **Person** template from the
 
 **DefaultSelectedItems** – The initial selected item(s) before the user interacts with the control.
 
+> [!NOTE]
+> This control also contains a property called Default. It doesn't do anything, use DefaultSelectedItems instead.
+
 **SelectedItems** – List of selected items resulting from user interaction.
 
 **SelectMultiple** – Whether the user can select a single item or multiple items.


### PR DESCRIPTION
After a few hours of banging heads against walls, we noticed that the combo box, differently than most controls, does not use the Default property to set the default selected item. Adding a note here in the documentation to prevent more brain trauma.