### PR TITLE
Update export-data-lake-faq.yml

### DIFF
--- a/powerapps-docs/maker/data-platform/export-data-lake-faq.yml
+++ b/powerapps-docs/maker/data-platform/export-data-lake-faq.yml
@@ -18,7 +18,6 @@ sections:
    - question: Does adding multiple Microsoft Dataverse tables simultaneously to the lake impact performance?
      answer: |
         Adding multiple tables to the Azure Synapse Link profile will impact performance in following scenarios: 
-        - Initial sync: When the tables are first added, there is a fixed set of tables which are synched for initial data at a time. We recommend adding no more than 5 tables at a time to new or existing profile. Adding more than the recommend number of tables doesn't expedite the sync since only the fixed set of tables are processed at a given time.  
         - Delta sync: After the initial sync of tables are completed, any change in Dataverse for selected tables is added to a common queue in Azure Synapse Link. The queue is processed with a fixed set of parallel listeners. If you add more tables to the queue, Azure Synapse Link will process the messages, but if the number of messages are higher, it will add latency for data to sync to synapse and/or the data lake. 
    - question: How can I access my table relationships?
      answer: |

--- a/powerapps-docs/maker/data-platform/export-data-lake-faq.yml
+++ b/powerapps-docs/maker/data-platform/export-data-lake-faq.yml
@@ -17,7 +17,7 @@ sections:
   questions:
    - question: Does adding multiple Microsoft Dataverse tables simultaneously to the lake impact performance?
      answer: |
-        Adding multiple tables to the Azure Synapse Link profile will impact performance in following scenarios: 
+        Adding multiple tables to the Azure Synapse Link profile will impact performance in following scenario: 
         - Delta sync: After the initial sync of tables are completed, any change in Dataverse for selected tables is added to a common queue in Azure Synapse Link. The queue is processed with a fixed set of parallel listeners. If you add more tables to the queue, Azure Synapse Link will process the messages, but if the number of messages are higher, it will add latency for data to sync to synapse and/or the data lake. 
    - question: How can I access my table relationships?
      answer: |


### PR DESCRIPTION
There is no upper limit to the number of tables user can sync at the initial stage.