### PR TITLE
Clarification of duration dimensions

### DIFF
--- a/powerapps-docs/maker/canvas-apps/application-insights.md
+++ b/powerapps-docs/maker/canvas-apps/application-insights.md
@@ -318,6 +318,7 @@ A set of default dimensions is also added to the *customDimensions* property on 
 | ms-appId        | The Application ID of the app that sent the event.     |
 | ms-appName      | The Application name of the app that sent the event.   |
 | ms-appSessionId | The application session ID.                           |
+| ms-duration     | An imputed value measuring the it takes for a user to navigate from one screen to another. This value overrides the standard App Insights PageView duration dimension. |
 
 ## Unsupported scenarios
 


### PR DESCRIPTION
Added row to custom dimension table to describe the ms-duration custom dimension and duration standard dimension