### PR TITLE
AppCenter iOS is called iOS not custom

### DIFF
--- a/powerapps-docs/maker/common/wrap/how-to.md
+++ b/powerapps-docs/maker/common/wrap/how-to.md
@@ -122,6 +122,8 @@ Use your [primary canvas app](overview.md#primary-app) to create a wrap project 
 
 To create a wrap project, go to the preview version of [Power Apps](https://make.preview.powerapps.com) > **Apps** > select the primary canvas app > select **Wrap**, and enter the wrap project details described in this section. After entering all details, select **Save** > **Build** to build the project.
 
+![image](https://user-images.githubusercontent.com/30095306/163098375-a6ca1267-0d9c-48a6-a42b-6092a9226bbf.png)
+
 Depending on the platform chosen, the build process queues the requests to create your packages for Android, iOS, or Google platforms.
 
 > [!NOTE]

--- a/powerapps-docs/maker/common/wrap/how-to.md
+++ b/powerapps-docs/maker/common/wrap/how-to.md
@@ -79,7 +79,7 @@ In this step, you'll use App Center to create an app container for your mobile a
 1. Select **Apps** &gt; **Add app**.
 1. Enter app name.
 1. Select app release type.
-1. Select **Custom** OS for iOS apps, or **Android** OS for Android apps.
+1. Select **iOS** OS for iOS apps, or **Android** OS for Android apps.
 
     > [!NOTE]
     > You must create separate App Center containers for each platform.

--- a/powerapps-docs/maker/common/wrap/how-to.md
+++ b/powerapps-docs/maker/common/wrap/how-to.md
@@ -108,7 +108,7 @@ In this step, you'll use App Center to create an app container for your mobile a
     1. Select **New API token**.
     1. Enter a description.
     1. Select **Full Access**.
-    1. Select **New API token**.
+    1. Select **Add new API token**.
         > [!NOTE]
         > Ensure you copy the token before closing the dialog box.
     1. Copy the token, and save it for canvas app wrap configuration [later](#app-center-api-token).


### PR DESCRIPTION
AppCenter iOS is called iOS not custom.

See the screenshot below.
![image](https://user-images.githubusercontent.com/30095306/163093585-9141b3e0-b14f-4843-9d61-986355023bb8.png)
