### PR TITLE
Add description for if record is not found

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-WebApi/retrieveRecord.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-WebApi/retrieveRecord.md
@@ -77,6 +77,7 @@ contributors:
 ## Return Value
 
 On success, returns a promise containing a JSON object with the retrieved columns and their values.
+If the requested record does not exist, returns an error.
 
 ## Examples
 


### PR DESCRIPTION
I think it's important to make it clear that it will return an error rather than a success with a null or empty value.
I see a lot of people doing things like the below because they don't understand what happens if the record is not found:
```JavaScript
Xrm.WebApi.retrieveRecord('contact', '299ff2e2-ff44-4c71-9b12-4738bcd76ffe')
    .then(result => {
        // People think it will return null if the record is not found
        if (result !== null) {
            // Do something
        }
    })
```