### PR TITLE
Fix heading level

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Utility/getGlobalContext/userSettings.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Utility/getGlobalContext/userSettings.md
@@ -145,7 +145,7 @@ Returns a promise which resolves with an object whose keys are the security role
 
 `userSettings.getSecurityRolePrivilegesInfo().then(successCallback, errorCallback);`
 
-## Parameters
+### Parameters
 
 <table>
 <tr>


### PR DESCRIPTION
Fix heading level for getSecurityRolePrivilegesInfo -> Parameters. It was set to heading 2 but should have been heading 3