### PR TITLE
Changed title to reflect correct function name

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Utility/getGlobalContext/isOnPremises.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Utility/getGlobalContext/isOnPremises.md
@@ -1,5 +1,5 @@
 ---
-title: "isOnPremise (Client API reference) in model-driven apps| MicrosoftDocs"
+title: "isOnPremises (Client API reference) in model-driven apps| MicrosoftDocs"
 description: Includes description and supported parameters for the isOnPremises method.
 ms.author: jdaly
 author: adrianorth


### PR DESCRIPTION
The title 'isOnPremise...' has a missing 's' since the function name is 'isOnPremises'.