### PR TITLE
Add step for making environment active

### DIFF
--- a/powerapps-docs/developer/data-platform/webapi/setup-postman-environment.md
+++ b/powerapps-docs/developer/data-platform/webapi/setup-postman-environment.md
@@ -64,6 +64,10 @@ contributors:
    
 1. Click **Save** to save your newly created environment named <b>MyNewEnvironment</b>.
 
+1. With your newly created environment selected, set it as the "active" one by either:
+  1. Clicking the ellipses menu near the top-right and selecting "Set as active environment", or
+  2. Clicking the environment dropdown in the top-right and selecting "<b>MyNewEnvironment</b>".
+
 ### Generate an access token to use with your environment
 
 To connect using **OAuth 2.0**, you must have an access token. Use the following steps to get a new access token:

--- a/powerapps-docs/developer/data-platform/webapi/setup-postman-environment.md
+++ b/powerapps-docs/developer/data-platform/webapi/setup-postman-environment.md
@@ -64,9 +64,9 @@ contributors:
    
 1. Click **Save** to save your newly created environment named <b>MyNewEnvironment</b>.
 
-1. With your newly created environment selected, set it as the "active" one by either:
-  1. Clicking the ellipses menu near the top-right and selecting "Set as active environment", or
-  2. Clicking the environment dropdown in the top-right and selecting "<b>MyNewEnvironment</b>".
+1. With your newly created environment selected, set it as the *active* one by either:
+  - Clicking the ellipses menu near the top-right and selecting **Set as active environment**, or
+  - Clicking the environment dropdown in the top-right and selecting **MyNewEnvironment**".
 
 ### Generate an access token to use with your environment
 


### PR DESCRIPTION
It took me a bit to figure out why Postman couldn't read my `{{authurl}}` and it's because I didn't have an active environment selected

![image](https://user-images.githubusercontent.com/40401643/182257342-0cb9990a-8178-4918-a0ec-bc69236b95c8.png)
