### PR TITLE
Update navigate-to-custom-page-examples.md

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/navigate-to-custom-page-examples.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/navigate-to-custom-page-examples.md
@@ -194,9 +194,13 @@ A more complete example of this can be found at [Override the default open behav
 1. Customize the table ribbon **CommandDefinition** for **OpenRecordItem** to call the function above and include the **CrmParameter** with the value **SelectedControlSelectedItemReferences**.
 
     ```xml
-        <JavaScriptFunction FunctionName="run" Library="$webresource:cr62c_OpenCustomPage">
-            <CrmParameter Value="SelectedControlSelectedItemReferences" />
-        </JavaScriptFunction>
+        <CommandDefinition Id="Mscrm.OpenRecordItem">
+            <Actions>
+                <JavaScriptFunction FunctionName="run" Library="$webresource:cr62c_OpenCustomPage">
+                    <CrmParameter Value="SelectedControlSelectedItemReferences" />
+                </JavaScriptFunction>
+            </Actions>
+        </CommandDefinition>
     ```
 
 1. In the custom page, override the **App**'s **OnStart** property to use the `Param` function to get the `recordId` and lookup record.


### PR DESCRIPTION
Clarified the example of where to place the XML override for CommandDefinition OpenRecordItem.