### PR TITLE
Add known issue: "$&" converted to "{3}amp;"

### DIFF
--- a/powerapps-docs/maker/model-driven-apps/rich-text-editor-control.md
+++ b/powerapps-docs/maker/model-driven-apps/rich-text-editor-control.md
@@ -1121,6 +1121,9 @@ A. If the image file name is long or contains many full-width characters, it may
 > [!div class="mx-imgBorder"] 
 > ![HTML markup displayed in a column on a subgrid.](media/html-markup-issue.png)
 To resolve this issue, see [Simple configuration](#simple-configuration) for the steps necessary to set the **Format** option to **Rich text**.
+	
+- When creating a note in Timeline, "$&" is converted to "{3}amp;"
+> To resolve this, add `"removePlugins": "stickystyles"` to your configuration file.
 
 
 ### See also


### PR DESCRIPTION
Making this change to address this GB cert bug
[Bug 2993198:](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/2993198) [GB Cert] [D365 for Sales] [Online] [GB/EN]: $& change to html or url address code when add note in Timeline section

In Timeline, the character sequence "$&" will be converted to "{3}amp;" after saving or editing a note. Removing the stickystyles plugin resolves the issue, "$&" will be displayed as normal.