### PR TITLE
Asynchronous plug-in steps and workflows

### DIFF
--- a/powerapps-docs/developer/data-platform/bypass-custom-business-logic.md
+++ b/powerapps-docs/developer/data-platform/bypass-custom-business-logic.md
@@ -198,7 +198,7 @@ Yes, But only when the plug-in is running in the context of a user who has the `
 
 ### What about asychronous plug-in steps, asynchronous workflows and flows?
 
-Asynchronous logic is not bypassed. Asynchronous logic doesn't significantly contribute to the cost of processing the records, therefore it is not by passed by this parameter.
+Asynchronous logic is bypassed in terms of plug-in steps and asynchronous workflows. Power Automate flows are not impacted by the flag.
 
 ## See also
 


### PR DESCRIPTION
We discovered recently that asynchronous plug-in steps and workflows are not runnning anymore when bypass custom plugins is enabled for requests. We did test it back and forth and could verify this behavior consistently.