### PR TITLE
Add known issue: "$&" converted to "{3}amp;"

### DIFF
--- a/powerapps-docs/maker/model-driven-apps/set-up-timeline-control.md
+++ b/powerapps-docs/maker/model-driven-apps/set-up-timeline-control.md
@@ -591,6 +591,9 @@ Power platform administrators can restrict the file size of attachments users ca
 1.	On the **System Settings** dialog, select the **Email** tab, and then scroll down to find the **Set file size limit for attachments** value.
 1.	Enter the desired size limit for attachments, and then select **Save**.
 
+## Known Issues
+ - When creating a note in Timeline, the character string "$&" is converted to "{3}amp;"
+> This is a configuration issue for the rich text editor control. To resolve this, add `"removePlugins": "stickystyles" ` to your RTE config file. See the [rich text documentation](https://learn.microsoft.com/en-us/power-apps/maker/model-driven-apps/rich-text-editor-control#create-and-use-advanced-configuration-for-the-rich-text-editor-control) for more information.
 
 ### See also
 


### PR DESCRIPTION
Making this change to address this GB cert bug
[Bug 2993198:](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/2993198) [GB Cert] [D365 for Sales] [Online] [GB/EN]: $& change to html or url address code when add note in Timeline section

In Timeline, the character sequence "$&" will be converted to "{3}amp;" after saving or editing a note with RTE configured. Removing the stickystyles plugin resolves the issue, "$&" will be displayed as normal.