### PR TITLE
Update implementing-controls-using-typescript.md

### DIFF
--- a/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
+++ b/powerapps-docs/developer/component-framework/implementing-controls-using-typescript.md
@@ -355,6 +355,16 @@ Developers and app makers can define their styling to represent their code compo
 > Power Apps component framework uses the concept of implementing String(resx) web resources that is used to manage the localized strings shown on any user interface. More information: [String(Resx) web resources](/dynamics365/customerengagement/on-premises/developer/resx-web-resources).
 > See [Localization API](sample-controls/localization-api-control.md) sample, to learn how to localize  code components using `resx` web resources. 
 
+## Add TypeScript plugin
+
+The eslintrc.josn file is configured to use JavasScript rules rather than TypeScript ones. To fix this, add the plugin line to the extends property.
+
+```
+"extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ]
+```
 
 ## Build your code components
 


### PR DESCRIPTION
When reproducing the described steps, I got an error, that resulted in the npm run build not working.

<img width="541" alt="image" src="https://user-images.githubusercontent.com/50626860/209329751-aad57874-e13d-4937-97d5-da8a1f26a2c8.png">

I found the article below that resolved my issue.
https://www.develop1.net/public/post/2021/11/08/componentframework-is-not-defined-with-pac-pcf-init

I've implemented this step in this md file.