### PR TITLE
Update code-components-best-practices.md

### DIFF
--- a/powerapps-docs/developer/component-framework/code-components-best-practices.md
+++ b/powerapps-docs/developer/component-framework/code-components-best-practices.md
@@ -164,6 +164,16 @@ Before you can use `eslint`, you need to add some scripts to the `package.json`:
   }
 ```
 
+You also need to specify the React version by ading the script below to `package.json`:
+
+```json
+,
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    }
+```
 
 The `eslint` script accepts the folder that contains your code. Replace **MY_CONTROL_NAME** to be the same name as the code component used when calling [pac pcf init](/power-platform/developer/cli/reference/pcf#pac-pcf-init).
 


### PR DESCRIPTION
The linting is explained and useful for a tutorial, but it gives some errors because the react version is not specified. I've added this step.

<img width="864" alt="image" src="https://user-images.githubusercontent.com/50626860/209335860-166717dc-06ba-4fd7-bfe3-9b723e5e337b.png">
