### PR TITLE
Web API ist not available for canvas apps

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/webapi.md
+++ b/powerapps-docs/developer/component-framework/reference/webapi.md
@@ -18,7 +18,7 @@ contributors:
 
 ## Available for 
 
-Model-driven apps, canvas apps, & portals.
+Model-driven apps & portals.
 
 ## Methods
 


### PR DESCRIPTION
Currently the documentation is inconsistent and misleading about availability of Web API in canvas apps.  