### PR TITLE
Updated Test Studio known limitation

### DIFF
--- a/powerapps-docs/maker/canvas-apps/test-studio.md
+++ b/powerapps-docs/maker/canvas-apps/test-studio.md
@@ -102,6 +102,7 @@ While work to provide full control coverage in Power Apps Test Studio is in prog
 - Formula-level error management experimental feature needs to be turned on for the app.
 - Support for controls not listed in the [Select](./functions/function-select.md) and [SetProperty](./functions/function-setproperty.md) functions.
 - Person-type columns.
+- Test Studio is not compatible with the experimental [Git Version Control feature](./git-version-control.md), and will not work properly if that feature is enabled.
 
 ## Next steps
 


### PR DESCRIPTION
Adding a known limitation bullet point to note that Test Studio does not work with Git Version Control.  This is a common issues that is talked about on the Git Version Control doc page, but has not been mentioned on the Test Studio page.