### PR TITLE
Update component-framework-for-canvas-apps.md

### DIFF
--- a/powerapps-docs/developer/component-framework/component-framework-for-canvas-apps.md
+++ b/powerapps-docs/developer/component-framework/component-framework-for-canvas-apps.md
@@ -15,9 +15,9 @@ contributors:
 
 # Code components for canvas apps
 
-App makers can use Power Apps component framework to create code components that can be used in their canvas apps. More information: [Power Apps component framework overview](overview.md) 
+Professional developers can use Power Apps component framework to create code components that can be used in their canvas apps. More information: [Power Apps component framework overview](overview.md) 
 
-Professional developers can use Power Apps component framework to create, import, and add code components to canvas apps by using [Microsoft Power Platform CLI](get-powerapps-cli.md). Certain APIs might not be available in canvas apps. We recommend that you check each API to determine where it's available.  
+App makers can use Power Apps component framework to create, import, and add code components to canvas apps by using [Microsoft Power Platform CLI](get-powerapps-cli.md). Certain APIs might not be available in canvas apps. We recommend that you check each API to determine where it's available.  
 
 ## Security considerations
 


### PR DESCRIPTION
in the first paragraph, I reversed the order of App Maker and Professional Developer tasks. It should be the Professional Developers who develop the PCFs, while the Makers import them into their applications