### PR TITLE
Update azure-synapse-link-synapse.md

### DIFF
--- a/powerapps-docs/maker/data-platform/azure-synapse-link-synapse.md
+++ b/powerapps-docs/maker/data-platform/azure-synapse-link-synapse.md
@@ -41,7 +41,7 @@ You can use the Azure Synapse Link to connect your Microsoft Dataverse data to A
 
 - Dataverse: You must have the Dataverse **system administrator** security role. Additionally, tables you want to export via Synapse Link must have the **Track changes** property enabled. More information: [Advanced options](create-edit-entities-portal.md#advanced-options)
 
-- Azure Data Lake Storage Gen2: You must have an Azure Data Lake Storage Gen2 account and **Owner** and **Storage Blob Data Contributor** role access. Your storage account must enable **Hierarchical namespace** and **public network access** for both initial setup and delta sync. **Allow storage account key access** is required only for the initial setup.  
+- Azure Data Lake Storage Gen2: You must have an Azure Data Lake Storage Gen2 account and **Owner** and **Storage Blob Data Contributor** and **Storage Blob Data Reader** role access. Your storage account must enable **Hierarchical namespace** and **public network access** for both initial setup and delta sync. **Allow storage account key access** is required only for the initial setup.  
 
 - Synapse workspace: You must have a Synapse workspace and the **Synapse Administrator** role access within the Synapse Studio. The Synapse workspace must be in the same region as your Azure Data Lake Storage Gen2 account with **allowAll** IP addresses access rule. The storage account must be added as a linked service within the Synapse Studio. To create a Synapse workspace, go to [Creating a Synapse workspace](/azure/synapse-analytics/get-started-create-workspace).
 


### PR DESCRIPTION
Changed the prerequisites to also include the Storage Blob Data Reader role, as if that role was not included in our instance, we received an error that stated that out client/user does not have authorization to preform action 'Microsoft.Authorization/roleAssignments/write over scope '/subscriptuons/"client subscription ID"/resourceGroups/"Client Resource group"/storageAccounts/"Client selected storage account"/providers/Microsoft. Authorization/roleAssignments' or the scope was invalid.

The only thing that fixed the issue was to assign the Storage Blob Data Reader to the user doing the setup as well