### PR TITLE
[PCF] Document the availability of the pfx-default-value in PCF properties

### DIFF
--- a/powerapps-docs/developer/component-framework/manifest-schema-reference/property.md
+++ b/powerapps-docs/developer/component-framework/manifest-schema-reference/property.md
@@ -31,8 +31,15 @@ Model-driven and canvas apps
 |of-type-group |Name of the type-group as defined in manifest| string |Optional |Model-driven apps|
 |description-key |Used in the customization screens as localized strings that describes the description of the property. |string |Optional |Model-driven and canvas apps|
 |default-value |The default configuration value provided to the component. In model-driven apps, this property is only allowed on inputs since the bound parameters expect to have a column associated. |string |Optional |Model-driven apps|
+|pfx-default-value |A PFX expression that can replace the static default configuration value. This can reference variables, functions, connectors, and other types supported in PFX. See [Remarks](#remarks) |string |Optional |Canvas apps|
 
 ### Remarks
+
+If the `pfx-default-value` property value includes quotation marks or other special characters, it is best to wrap the value in single quotes, i.e.,
+`pfx-default-value='"Test"'`
+
+If the `pfx-default-value` property value includes enum values, the enum must be wrapped in these special characters:
+`pfx-default-value='%MyEnumType.RESERVED%.MyEnumValue'`
 
 The `of-type` property value must be one of the following:
 


### PR DESCRIPTION
Design Doc: Supporting Default PFX Properties in Canvas PCF https://microsoft.sharepoint.com/:u:/t/PowerApps7/Eep9iWsqTttOre0ZLdOHpbgBWV2FVYOx_X1pgfkj0sNb4g?e=WZQB0W 

First-party PCFs can now support PFX expressions as default properties. This enables scenarios like these:

Apply control level theming to modern controls
<property name="BaseColor" of-type="SingleLine.Text" pfx-default-value="App.Theme.Colors.BaseColor"...

Assign responsive dimensions out of the box
<common-property name="Width" pfx-default-value="Parent.Width" />

Import images and files from default connectors
<property name="UserAvatar" of-type="Image" pfx-default-value="User().Image"...

Demonstrate how custom objects and data sets are formatted
<data-set name="Items" pfx-default-value='["Item1", "Item2", "Item3"]'…