### PR TITLE
Update azure-synapse-link-delta-lake.md

### DIFF
--- a/powerapps-docs/maker/data-platform/azure-synapse-link-delta-lake.md
+++ b/powerapps-docs/maker/data-platform/azure-synapse-link-delta-lake.md
@@ -69,6 +69,9 @@ This configuration can be considered a bootstrap step for average use cases.
 - Number of minutes idle: 5
 - Apache Spark: 3.1
 
+> [!NOTE]
+> Users in a Subscription type that limits the number of vCores to 12 (such as Pay-As-You-Go subscriptions) need to increase their vCore allocation, as the recommended configuration listed above requires at least 20 vCores.
+
 ## Connect Dataverse to Synapse workspace and export data in Delta Lake format
 
 1. Sign into [Power Apps](https://make.powerapps.com/?utm_source=padocs&utm_medium=linkinadoc&utm_campaign=referralsfromdoc) and select the environment you want.


### PR DESCRIPTION
Added a note around recommended spark cluster configuration to advise users on lower tier subscriptions that their subscription may need a vCore quota increase in order to successfully set up Synapse Link in the Delta Lake format.