### PR TITLE
Update add-ai-chatbot.md limitations

### DIFF
--- a/powerapps-docs/maker/canvas-apps/add-ai-chatbot.md
+++ b/powerapps-docs/maker/canvas-apps/add-ai-chatbot.md
@@ -87,6 +87,7 @@ The following are the main properties for Chatbot control:
 
 1. Chatbot control isn't supported on the Power Apps mobile app.
 2. Chatbot control isn't available in [Power Apps US Government](/power-platform/admin/powerapps-us-government) or Mooncake.
+3. Chatbot control does not support regional PVA bots.
 
 ## See also
 


### PR DESCRIPTION
Adding limitation for the chatbot control specifying that it does not support connecting to regional PVA bots