### PR TITLE
docs(component-framework): setValue does not accept EntityReference instead it allows only the LookupValue format

### DIFF
--- a/powerapps-docs/developer/component-framework/reference/entityrecord/setValue.md
+++ b/powerapps-docs/developer/component-framework/reference/entityrecord/setValue.md
@@ -28,7 +28,7 @@ Model-driven and canvas [experimental](../../../../maker/canvas-apps/working-wit
 |Parameter Name |Type| Required | Description|
 |----|----|----|----|
 | `columnName`|`string`| Yes| The logical name of the column.|
-| `value`|`string`<br />`Date`<br />`number`<br />`number[]`<br />`boolean`<br />[EntityReference](./../entityreference.md)<br />`EntityReference[]`<br />[FileObject](./../fileobject.md)<br />[ImageObject](./../imageobject.md)| Yes      | New value for the record. |
+| `value`|`string`<br />`Date`<br />`number`<br />`number[]`<br />`boolean`<br />[LookupValue](./../lookupvalue.md)<br />`LookupValue[]`<br />[FileObject](./../fileobject.md)<br />[ImageObject](./../imageobject.md)| Yes      | New value for the record. |
 
 ## Return Value
 


### PR DESCRIPTION
The docs are currently stating that the method `setValue` is allowing `EntityReference` to be passed.
This is not the case. The current implementation only allows the format of `LookupValue`.

This should be reflected in the docs. Or the implementation needs to be adjusted in order to support `EntityReference`.

Rel. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63303#issuecomment-2107213564