### PR TITLE
Fix wrong return type in getEventSource example

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/executioncontext/getEventSource.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/executioncontext/getEventSource.md
@@ -24,7 +24,7 @@ Returns a reference to the object that the event occurred on.
 
 **Type**: Object
 
-**Description**: Returns the object from the **Xrm** object model that is the source of the event, not an HTML DOM object. For example, in an [OnChange](../events/attribute-onchange.md) event, this method returns the **formContext.data.entity**  object that represents the changed column.
+**Description**: Returns the object from the **Xrm** object model that is the source of the event, not an HTML DOM object. For example, in an [OnChange](../events/attribute-onchange.md) event, this method returns the **formContext.data.entity.attributes**  object that represents the changed column.
 
 [!INCLUDE[cc-terminology](../../../../data-platform/includes/cc-terminology.md)]
 


### PR DESCRIPTION
The OnChange event returns formContext.data.entity.attributes and not formContext.data.entity (as also seen in the event table below).