### PR TITLE
Update azure-synapse-link-msi.md

### DIFF
--- a/powerapps-docs/maker/data-platform/azure-synapse-link-msi.md
+++ b/powerapps-docs/maker/data-platform/azure-synapse-link-msi.md
@@ -19,6 +19,7 @@ With managed identities, access to your storage account is restricted to request
 
 ## Before you start
 
+- Powershell 7.4 or above. Check your version on `$PSVersionTable`
 - Azure CLI is required on your local machine. [Download and install](https://aka.ms/InstallAzureCliWindows)
 - You need these two PowerShell modules. If you don't have them, open PowerShell and run these commands:
   - Azure Az PowerShell module: `Install-Module -Name Az`


### PR DESCRIPTION
Added note under prerequisites to work on Powershell 7.4 or above.

Reason: Noticed compatibility issues when these steps were run on the default Windows Powershell version (5.1) with data types that prevented the scripts  from executing:
"Message=The request content was invalid and could not be deserialized:" on script EnterprisePolicyOperations.ps1, function "PutEnterprisePolicy", on line "New-AzResourceGroupDeployment..".

Running the steps on 7.4.2 Core works as expected.