### PR TITLE
Add print to list of unsupported commands

### DIFF
--- a/powerapps-docs/maker/model-driven-apps/commanding-use-powerfx.md
+++ b/powerapps-docs/maker/model-driven-apps/commanding-use-powerfx.md
@@ -213,6 +213,7 @@ The following Power Fx functions are currently not supported with commanding in 
 - Language()
 - LoadData()
 - Param()
+- Print()
 - ReadNFC()
 - RequestHide()
 - ResetForm()


### PR DESCRIPTION
Print is not supported in command designer, updating documentation