### PR TITLE
fix: c# code sample causes duplicate first page

### DIFF
--- a/powerapps-docs/developer/data-platform/fetchxml/page-results.md
+++ b/powerapps-docs/developer/data-platform/fetchxml/page-results.md
@@ -143,7 +143,7 @@ static EntityCollection RetrieveAll(IOrganizationService service, string fetchXm
         // Set the fetch paging-cookie attribute with the paging cookie from the previous query
         fetchNode.SetAttributeValue("paging-cookie", results.PagingCookie);
 
-        fetchNode.SetAttributeValue("page", page++);
+        fetchNode.SetAttributeValue("page", ++page);
     }
     return new EntityCollection(entities);
 }


### PR DESCRIPTION
The `page` variable only gets updates _after_ its used in the while loop causes the page numbers it go: 1, 1, 2, 3...