### PR TITLE
Syntax Correction in myHandler Function Promise

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/events/form-onsave.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/events/form-onsave.md
@@ -55,7 +55,7 @@ For example:
 
 ```JavaScript
  function myHandler() {
-    return Promise.all([getWorkOrderPromise, getCustomerAssetPromise]).then((values)) => {
+    return Promise.all([getWorkOrderPromise, getCustomerAssetPromise]).then((values) => {
         var workOrder = values[0];
         var customerAsset = values[1];
         // Perform validation


### PR DESCRIPTION
This pull request fixes a syntax issue in the myHandler function.
The line using Promise.all has been updated to ensure correct syntax for the arrow function's parentheses.