### PR TITLE
Update data-platform-mcp.md

### DIFF
--- a/powerapps-docs/maker/data-platform/data-platform-mcp.md
+++ b/powerapps-docs/maker/data-platform/data-platform-mcp.md
@@ -167,9 +167,7 @@ If you don’t have VS Code installed, [download Visual Studio Code - Mac, Linux
 
 These instructions help you configure a Dataverse MCP server at the user setting level.
 
-1. In VS Code, go to **Manage** (gear on lower left) > **Settings** or CTRL+, and then type *MCP*.
-1. **Mcp** is listed under the **User** tab. Select **Edit in settings.json**.
-   :::image type="content" source="media/mcp-edit-vsc.png" alt-text="Edit Mcp JSON in VS Code":::
+1. In VS Code, open the command palette using Ctrl+Shift+P or **View** > **Command Palette**. Type *MCP: Open User Configuration*
 1. Add the Dataverse MCP configuration text inside the mcp "servers" setting following the curly brace.
    :::image type="content" source="media/mcp-dataverse-json.png" alt-text="JSON snippet location for MCP Dataverse":::
 


### PR DESCRIPTION
The way to add an MCP server is changed, it is no longer in the settings, you now must open a separate settings file.

Confirmed in vscode and also confirmed by other documentation:  https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server-to-your-workspace