### PR TITLE
Fix placeholder syntax in email template dynamic text documentation

### DIFF
--- a/powerapps-docs/user/email-dynamic-text.md
+++ b/powerapps-docs/user/email-dynamic-text.md
@@ -53,9 +53,9 @@ Use the following syntax:
 | Date  | `{!EntityLogicalName:FieldLogicalName/@date;}` |
 | Time | `{!EntityLogicalName:FieldLogicalName/@time;}` |
 
-For example, let's say you want to insert a custom field, *Customer ID*, linked to the record type *User*. Type the following placeholder in your template: ``{{!User:CustomerId;}}``.
+For example, let's say you want to insert a custom field, *Customer ID*, linked to the record type *User*. Type the following placeholder in your template: ``{!User:CustomerId;}``.
 
-If you want to insert a custom field, *ModifiedOn*, linked to the record type *User*. Type the following placeholder in your template: ``{{!User:ModifiedOn/@date;}}``.
+If you want to insert a custom field, *ModifiedOn*, linked to the record type *User*. Type the following placeholder in your template: ``{!User:ModifiedOn/@date;}``.
 
 ### See also
 


### PR DESCRIPTION
While a minor difference, this is picked up by LLMs and provides incorrect suggestions. {{ }} notation is used in email messages. Templates only support {! ;} notation. 