### PR TITLE
Update description of shortcuts

### DIFF
--- a/powerapps-docs/maker/data-platform/azure-synapse-link-view-in-fabric.md
+++ b/powerapps-docs/maker/data-platform/azure-synapse-link-view-in-fabric.md
@@ -19,7 +19,7 @@ Microsoft Dataverse direct link to Microsoft Fabric enables organizations to ext
 - Link data from all Dynamics 365 apps, including Dynamics 365 Finance and Operations apps.
 - Build Power Apps and automations to drive action from insights in OneLake.
 
-[Microsoft OneLake](/fabric/onelake/onelake-overview), a data lake built into Fabric, helps eliminate data silos. Combine data from your applications and devices web sites, mobile apps, sensors, and signals from your warehouse and factories with data from your business processes in Dynamics 365, such as sales, cases, inventory, and orders, to predict potential delays or shortages that affect keeping your promises to customers. Dataverse creates shortcuts to OneLake, which enables you to work with data without making multiple copies.
+[Microsoft OneLake](/fabric/onelake/onelake-overview), a data lake built into Fabric, helps eliminate data silos. Combine data from your applications and devices web sites, mobile apps, sensors, and signals from your warehouse and factories with data from your business processes in Dynamics 365, such as sales, cases, inventory, and orders, to predict potential delays or shortages that affect keeping your promises to customers. OneLake creates shortcuts to Dataverse, which enables you to work with data without making multiple copies.
 
 Dataverse also generates an enterprise-ready [Microsoft Fabric Lakehouse and SQL endpoint](/fabric/data-engineering/lakehouse-overview) and a Power BI dataset for your Power Apps and Dynamics 365 data. This makes it easier for data analysts, data engineers, and database admins to combine business data with data already present in OneLake using Spark, Python, or SQL. As data gets updated, changes are reflected in lakehouse automatically.
 


### PR DESCRIPTION
Based on the understanding that shortcuts are created in OneLake to point to Dataverse, changed "Dataverse creates shortcuts to OneLake, which enables you to work with data without making multiple copies" to "OneLake creates shortcuts to Dataverse, which enables you to work with data without making multiple copies".