### PR TITLE
Update create-edit-powerbi-embedded-page.md

### DIFF
--- a/powerapps-docs/maker/model-driven-apps/create-edit-powerbi-embedded-page.md
+++ b/powerapps-docs/maker/model-driven-apps/create-edit-powerbi-embedded-page.md
@@ -24,6 +24,9 @@ Read more about relevant Power BI licenses at [Power BI pricing](https://powerbi
 
 To learn more about Power BI reports and dashboards, go to [Create reports and dashboards in Power BI](/power-bi/create-reports/).
 
+> [!IMPORTANT]
+> The the Power BI report control is retired on July 31, 2024. We recommend removing all Power BI report controls from your model-driven apps and use Power BI embedded system dashboard embedding instead. More information: [Create or edit a Power BI embedded system dashboard](create-edit-powerbi-embedded-page.md)
+
 ## Create a system dashboard with Power BI embedded
 
 This procedure shows you how to set up a Power BI embedded page for a single environment connected to a Power BI workspace.
@@ -85,3 +88,4 @@ When a solution with a Power BI embedded component will be moved to other enviro
 
 
 [!INCLUDE[footer-include](../../includes/footer-banner.md)]
+


### PR DESCRIPTION
Misleading Information about the PowerBi Control for dataverse Model Driven App forms.

Misleading content from MS on how to integrate PowerBI with OOB form components. 

However, this component was in preview, and withdrawn, but Microsoft removed any trace of this. 

After few hours of investigation i identified this text https://github.com/MicrosoftDocs/powerapps-docs/commit/be92f82a69fb0b139bc226dc6f46de309f914981.  

MS Video still on youtube: https://www.youtube.com/watch?v=ZuXAqlQdOb4 

Third-party sample[: How to add Power BI Tiles to your D365 Form | Power Apps Tutorial](https://www.youtube.com/watch?v=f8dXqLMnNto)  

Resolution: Update documentation, clearly state this feature does not exist