### PR TITLE
Document generally available Xrm.Copilot methods

### DIFF
--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Copilot/includes/updatecontext-description.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Copilot/includes/updatecontext-description.md
@@ -1,1 +1,1 @@
-(preview) Sends updated app context to the Microsoft 365 Copilot side panel.
+Sends updated app context to the Microsoft 365 Copilot side panel.

--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Copilot/updatecontext.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/Xrm-Copilot/updatecontext.md
@@ -1,9 +1,9 @@
 ---
-title: "updateContext (Client API reference) in model-driven apps (preview)"
+title: "updateContext (Client API reference) in model-driven apps"
 description: Includes description and supported parameters for the updateContext method.
 author: devkeydet
 ms.author: marcsc
-ms.date: 06/02/2026
+ms.date: 08/10/2026
 ms.reviewer: jdaly
 ms.topic: reference
 applies_to: "Dynamics 365 (online)"
@@ -13,9 +13,7 @@ contributors:
   - JimDaly
 ---
 
-# updateContext (Client API reference) (preview)
-
-[!INCLUDE [preview-note-pp](~/../shared-content/shared/preview-includes/preview-note-pp.md)]
+# updateContext (Client API reference)
 
 [!INCLUDE[updatecontext-description](includes/updatecontext-description.md)]
 

--- a/powerapps-docs/developer/model-driven-apps/clientapi/reference/xrm-copilot.md
+++ b/powerapps-docs/developer/model-driven-apps/clientapi/reference/xrm-copilot.md
@@ -3,7 +3,7 @@ title: "Xrm.Copilot (Client API reference) in model-driven apps"
 description: Provides methods to execute registered Microsoft Copilot Studio Topics..
 author: devkeydet
 ms.author: marcsc
-ms.date: 06/16/2025
+ms.date: 08/10/2026
 ms.reviewer: jdaly
 ms.topic: reference
 applies_to: "Dynamics 365 (online)"
@@ -18,14 +18,12 @@ contributors:
 
 [!INCLUDE [xrm-copilot-description](Xrm-Copilot/includes/xrm-copilot-description.md)]
 
-## Methods
+## Generally available methods
 
 | Method| Description|
 | --- | --- |
 |[addActionHandler](Xrm-Copilot/addactionhandler.md)|[!INCLUDE [addactionhandler-description](Xrm-Copilot/includes/addactionhandler-description.md)]|
 |[addDefaultActionHandlers](Xrm-Copilot/adddefaultactionhandlers.md)|[!INCLUDE [adddefaultactionhandlers-description](Xrm-Copilot/includes/adddefaultactionhandlers-description.md)]|
-|[executeEvent](Xrm-Copilot/executeevent.md)|[!INCLUDE [executeevent-description](Xrm-Copilot/includes/executeevent-description.md)]|
-|[executePrompt](Xrm-Copilot/executeprompt.md)|[!INCLUDE [executeprompt-description](Xrm-Copilot/includes/executeprompt-description.md)]|
 |[getCurrentAgent](Xrm-Copilot/getcurrentagent.md)|[!INCLUDE [getCurrentAgent-description](Xrm-Copilot/includes/getCurrentAgent-description.md)]|
 |[isM365CopilotEnabled](Xrm-Copilot/ism365copilotenabled.md)|[!INCLUDE [ism365copilotenabled-description](Xrm-Copilot/includes/ism365copilotenabled-description.md)]|
 |[openM365CopilotPanel](Xrm-Copilot/openm365copilotpanel.md)|[!INCLUDE [openm365copilotpanel-description](Xrm-Copilot/includes/openm365copilotpanel-description.md)]|
@@ -33,6 +31,13 @@ contributors:
 |[removeDefaultActionHandlers](Xrm-Copilot/removedefaultactionhandlers.md)|[!INCLUDE [removedefaultactionhandlers-description](Xrm-Copilot/includes/removedefaultactionhandlers-description.md)]|
 |[sendPromptToM365Copilot](Xrm-Copilot/sendprompttom365copilot.md)|[!INCLUDE [sendprompttom365copilot-description](Xrm-Copilot/includes/sendprompttom365copilot-description.md)]|
 |[updateContext](Xrm-Copilot/updatecontext.md)|[!INCLUDE [updatecontext-description](Xrm-Copilot/includes/updatecontext-description.md)]|
+
+## Preview methods
+
+| Method| Description|
+| --- | --- |
+|[executeEvent](Xrm-Copilot/executeevent.md)|[!INCLUDE [executeevent-description](Xrm-Copilot/includes/executeevent-description.md)]|
+|[executePrompt](Xrm-Copilot/executeprompt.md)|[!INCLUDE [executeprompt-description](Xrm-Copilot/includes/executeprompt-description.md)]|
 
 ## Interfaces
 


### PR DESCRIPTION
## Summary

- Separate generally available and preview Xrm.Copilot methods into distinct tables
- Mark `updateContext` as generally available using standard documentation conventions
- Keep `executeEvent` and `executePrompt` labeled as preview

## Validation

- Confirmed the preview titles, notices, and descriptions remain in place for `executeEvent` and `executePrompt`
- Confirmed no preview labeling remains on `updateContext`