### PR TITLE
Update modern control docs: modernize Avatar and Spinner; add Toggle and Checkbox examples

### DIFF
--- a/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-avatar.md
+++ b/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-avatar.md
@@ -1,88 +1,163 @@
 ---
-title: Avatar modern control in Power Apps
-description: Learn about the details, properties, and examples of the avatar modern control in Power Apps.
-author: jasongre
-
+title: "Avatar Modern Control in Canvas Apps: Properties and Examples"
+description: "Discover how to use the Avatar modern control in Power Apps canvas apps. Learn key properties, presence badges, styling options, and examples to represent users and entities."
+author: yogeshgupta698
 ms.topic: reference
-ms.component: canvas
-ms.date: 10/8/2025
+ms.custom: canvas
+ms.date: 08/17/2026
 ms.subservice: canvas-maker
-ms.author: jasongre
-
-
+ms.author: yogupt
 ms.reviewer: mkaur
-search.audienceType: 
+search.audienceType:
   - maker
 contributors:
   - jasongre
-     
+  - yogeshgupta698
 ---
-# Avatar modern control in Power Apps
 
-A control that shows a graphic representation of a user, team, or entity.  
+# Avatar modern control in canvas apps
+
+A control that shows a graphic representation of a user, team, or entity, with an optional presence badge.
 
 ## Description
 
-Use the avatar control to visually represent a user, team, or entity. This control supports both image and initials formats and allows a small badge to be included to help convey status. The key properties for this control are **Name** and **Image**.  
+Use the **Avatar** modern control to visually represent a user, team, or entity. The control displays the image supplied in **Image**, falls back to initials derived from **Name**, and shows a generic person icon when neither value is available. You can also show a presence badge and, in the updated version, make the avatar respond to selection. Key properties for this control are **Name**, **Image**, and **Badge**.
+
+> [!NOTE]
+> This article describes the updated Avatar modern control. For information about what changed from the previous version, see [Recent updates](#recent-updates).
 
 ## General
 
-**Name** - The name of the person or entity. Name is used to determine the initials displayed when there's no image and is also used for accessibility. 
+**Name** – The name of the person or entity. The control uses this value to determine the initials that appear when there's no image, and for accessibility. The default is `User().FullName`.
 
-**Image** – The visual representation for the person or entity.
+**Image** – The visual representation for the person or entity. Accepts image URLs, data URIs, and Power Apps image references. The default is `User().Image`.
 
-**Badge** – A small visual decoration added to convey status of the person or entity. 
+**Badge** – A small visual decoration added to convey the status of the person or entity. Accepts `PresenceBadge` enum values. Use a blank value when no badge should appear.
 
-**Visible** - Whether a control appears or is hidden.
+| Value | Description |
+|-------|-------------|
+| `PresenceBadge.Available` | The person is available. |
+| `PresenceBadge.Busy` | The person is busy. |
+| `PresenceBadge.DoNotDisturb` | The person doesn't want to be disturbed. |
+| `PresenceBadge.Away` | The person is away. |
+| `PresenceBadge.Offline` | The person is offline. |
+| `PresenceBadge.OutOfOffice` | The person is out of office. |
+| `PresenceBadge.Unknown` | The status is unknown. |
 
-## Size and position 
+**Visible** – Whether the control appears or is hidden.
 
-**[X](../properties-size-location.md)** – The distance between the left edge of a control and the left edge of its parent container (screen if no parent container).
+## Behavior
 
-**[Y](../properties-size-location.md)** – The distance between the top edge of a control and the top edge of the parent container (screen if no parent container).
+**OnSelect** – Actions to perform when the user selects the avatar. When this property contains an active formula, the avatar becomes interactive and renders with button semantics, so it responds to Enter or Space while it has keyboard focus. When the property is blank, the avatar is display-only.
 
-**Width** - The distance between a control's left and right edges. 
+**DisplayMode** – Whether the control allows interaction (**Edit**), only displays content (**View**), or is disabled (**Disabled**). When **Disabled** and **OnSelect** is set, the avatar is dimmed and **OnSelect** doesn't fire.
 
-**Height** - The distance between a control's top and bottom edges. 
+## Size and position
+
+**[X](../properties-size-location.md)** – Distance between the left edge of the control and the left edge of its parent container (screen if no parent container).
+
+**[Y](../properties-size-location.md)** – Distance between the top edge of the control and the top edge of its parent container (screen if no parent container).
+
+**Width** – Distance between the control's left and right edges. Default is **64**.
+
+**Height** – Distance between the control's top and bottom edges. Default is **64**.
 
 ## Style and theme
 
-**Shape** - Whether the avatar appears with a circular or square shape. 
+**Shape** – Whether the avatar appears with a circular or square shape. Accepts `AvatarShape` enum values: `AvatarShape.Circular` (default) or `AvatarShape.Square`.
 
-**Appearance** – An avatar can have portions of itself styled for greater emphasis or to be subtle. 
+**Appearance** – An avatar can have portions of itself styled for greater emphasis or to be subtle. The following options are available:
 
-The following options are available:
-
-- **Brand**: Uses the modern theme to style the avatar. The Color palette property can be used to override this color scheme. 
+- **Brand**: Uses the modern theme to style the avatar. Use the **BasePaletteColor** property to override this color scheme.
 - **Neutral**: Uses a grayscale for the initials background to provide a subtle appearance.
-- **Colorful**: Users a color from a predefined set of colors, based on a hash of the provided Name. 
+- **Colorful**: Uses a color from a predefined set of colors, based on a hash of the provided **Name**.
 
-**BasePaletteColor** - The color palette applied to a control. This impacts all surfaces of the control that render a theme color. If the value is null or zero, then the color is driven by the selected Fluent theme.
+**BasePaletteColor** – The color palette applied to a control. This property impacts all surfaces of the control that render a theme color. If the value is null or zero, the color is driven by the selected Fluent theme.
 
-**Font** - The name of the family of fonts in which text appears.
+**Font** – The name of the family of fonts in which the initials appear.
 
-**FontSize** - The font size of the text that appears on a control. If the value is null or zero, then the font size is driven by selected Fluent theme.
+**Size** – The font size of the initials. If the value is null or zero, the font size is driven by the avatar dimensions.
 
-**FontColor** - The color of text in a control. 
+**Color** – The color of the initials. If not set, the control chooses a contrasting color based on **Appearance**.
 
-**FontWeight** - The weight of the text in a control: **Bold**, **Lighter**, **Normal**, or **Semibold**. 
+**FontWeight** – The weight of the initials. Accepts `FontWeight` enum values: `FontWeight.Bold`, `FontWeight.Semibold`, `FontWeight.Normal` (default), or `FontWeight.Lighter`.
 
-**FontItalic** - Whether the text in a control is italic. 
+**Italic** – Whether the initials appear in italic style.
 
-**FontUnderline** - Whether a line appears under the text that appears on a control. 
+**Underline** – Whether a line appears under the initials.
 
-**FontStrikethrough** - Whether a line appears through the text that appears on a control. 
+**Strikethrough** – Whether a line appears through the initials.
 
 ## Additional properties
 
-**Out of office** - Adjusts the Badge icon to show its corresponding "out of office" variant.  
+**AccessibleLabel** – Label read by screen readers. When not set, the control uses the **Name** value. When **OnSelect** is set, describe the action, for example `"Open profile for " & User().FullName`.
 
+**Tooltip** – Explanatory text that appears when the user hovers over the control.
 
+**ContentLanguage** – The display language for the control content, if different from the app language.
 
+## Example
 
+The following YAML example shows the current user's avatar with a presence badge, and a second avatar that opens a profile screen when selected:
 
+```yaml
+- CurrentUserAvatar:
+    Control: ModernAvatar@1.0.0
+    Properties:
+      Name: =User().FullName
+      Image: =User().Image
+      Badge: =PresenceBadge.Available
+      Shape: =AvatarShape.Circular
+      Appearance: ="Brand"
+      Tooltip: =User().FullName
+      Width: =64
+      Height: =64
 
+- EmployeeAvatar:
+    Control: ModernAvatar@1.0.0
+    Properties:
+      Name: =ThisItem.FullName
+      Image: =ThisItem.Photo
+      Badge: =PresenceBadge.Away
+      Shape: =AvatarShape.Square
+      Appearance: ="Colorful"
+      AccessibleLabel: ="Open profile for " & ThisItem.FullName
+      OnSelect: =Navigate(ProfileScreen)
+      Width: =48
+      Height: =48
+```
 
+## Recent updates
 
+The updated version of the **Avatar** modern control includes the following improvements and behavior changes.
 
+### Property renames
 
+The following properties are renamed. Update any formulas in your app that reference the old property names.
+
+| Previous property | New property |
+|---|---|
+| `FontSize` | `Size` |
+| `FontColor` | `Color` |
+| `FontItalic` | `Italic` |
+| `FontUnderline` | `Underline` |
+| `FontStrikethrough` | `Strikethrough` |
+
+### Removed properties
+
+| Removed property | Notes |
+|---|---|
+| `Out of office` | Removed. Use `Badge = PresenceBadge.OutOfOffice` to show the out-of-office presence instead. |
+
+### Bug fixes and improvements
+
+- **Updated enums**: `Badge` and `Shape` now use typed Power Fx enums (`PresenceBadge` and `AvatarShape`) instead of string values, improving IntelliSense and reducing formula errors. `FontWeight` uses the `FontWeight` enum.
+- **OnSelect support**: The avatar can now trigger actions when selected. When `OnSelect` is set, the control renders with button semantics and is fully accessible via keyboard and screen readers.
+- **Tooltip support**: New `Tooltip` property shows explanatory text on hover.
+- **Full font control**: Font properties are now consistent with other modern controls. Use `Font`, `Size`, `Color`, `Italic`, `Underline`, and `Strikethrough`.
+
+## See also
+
+- [Modern controls overview](overview-modern-controls.md)
+- [Recent updates to modern controls](modern-control-updates.md)
+- [Size and location properties](../properties-size-location.md)

--- a/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-checkbox.md
+++ b/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-checkbox.md
@@ -5,7 +5,7 @@ author: yogeshgupta698
 
 ms.topic: reference
 ms.component: canvas
-ms.date: 08/03/2026
+ms.date: 08/17/2026
 ms.subservice: canvas-maker
 ms.author: yogupt
 
@@ -78,6 +78,23 @@ The user can specify a Boolean value by using this familiar control that's been 
 **OnSelect** - Actions to perform when the user selects a control. 
 
 **OnUncheck** - Actions to perform when the user unchecks the control. 
+
+## Example
+
+The following YAML example shows a checkbox that the user must select to accept terms before continuing:
+
+```yaml
+- TermsCheckbox:
+    Control: ModernCheckbox@1.0.0
+    Properties:
+      Label: ="I accept the terms and conditions"
+      Checked: =false
+      OnCheck: =Set(varTermsAccepted, true)
+      OnUncheck: =Set(varTermsAccepted, false)
+      Tooltip: ="You must accept the terms to continue"
+```
+
+You can reference the checkbox's **Checked** property elsewhere in your app. For example, set a submit button's **DisplayMode** to `=If(TermsCheckbox.Checked, DisplayMode.Edit, DisplayMode.Disabled)` so users can continue only after they select the checkbox.
 
 ## Recent updates
 

--- a/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-spinner.md
+++ b/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-spinner.md
@@ -1,79 +1,154 @@
 ---
-title: Spinner modern control in Power Apps
-description: Learn about the details, properties, and examples of the spinner modern control in Power Apps.
+title: "Spinner Modern Control in Canvas Apps: Properties and Examples"
+description: "Discover how to use the Spinner modern control in Power Apps canvas apps. Learn key properties, sizes, styling options, and examples to show loading and in-progress states."
 author: yogeshgupta698
-
 ms.topic: reference
-ms.component: canvas
-ms.date: 3/23/2023
+ms.custom: canvas
+ms.date: 08/17/2026
 ms.subservice: canvas-maker
 ms.author: yogupt
-
-
 ms.reviewer: mkaur
-search.audienceType: 
+search.audienceType:
   - maker
 contributors:
   - mduelae
   - yogeshgupta698
   - noazarur-microsoft
-  
 ---
-# Spinner modern control in Power Apps
 
-Displays state in motion such as loading a page or table.
+# Spinner modern control in canvas apps
+
+Displays state in motion, such as loading a page or table.
 
 ## Description
-**Spinner** control can be used to display loading scenarios where an action is in progress. This powerful control provides multiple display options suited for many scenarios. The key properties for this control are **Label**, **Appearance**, and **SpinnerSize**.
+
+Use the **Spinner** modern control to display loading scenarios where an action is in progress. The control communicates an indeterminate wait, and you show or hide it based on the loading state of your app. Key properties for this control are **Label**, **Appearance**, and **SpinnerSize**.
+
+The Spinner is a display-only control. For progress that you can measure as a percentage, use the [Progress Bar modern control](modern-control-progress-bar.md).
+
+> [!NOTE]
+> This article describes the updated Spinner modern control. For information about what changed from the previous version, see [Recent updates](#recent-updates).
 
 ## General
 
-**Label** – The label to the spinner. The label slot receives the styling related to the text associated with the Spinner.
+**Label** – The label next to the spinner, such as `"Loading records..."`. The label slot receives the styling related to the text associated with the spinner.
 
-**AccessibleLabel** – Label for screen readers.
+**AccessibleLabel** – Label read by screen readers. When not set, the control uses the **Label** value. Describe the operation in progress, for example `"Loading customer records"`.
 
-**Visible** - Whether a control appears or is hidden.
+**Visible** – Whether the control appears or is hidden. Set this property to a Boolean value that represents the loading state.
+
+## Behavior
+
+**OnChange** – Actions to perform when a property of the spinner changes.
+
+**DisplayMode** – Whether the control allows user input (**Edit**), only displays data (**View**), or is disabled (**Disabled**). The spinner doesn't accept user input, so this property primarily affects the visual appearance.
 
 ## Size and position
 
-**LabelPosition** – Where the label is positioned relative to the spinner.
+**LabelPosition** – Where the label is positioned relative to the spinner. Accepts `LabelPosition` enum values: `LabelPosition.Before`, `LabelPosition.After` (default), `LabelPosition.Above`, or `LabelPosition.Below`.
 
-**SpinnerSize** – The size of the spinner.
+**SpinnerSize** – The size of the spinner. Accepts `SpinnerSize` enum values:
 
-**[X](../properties-size-location.md)** – The distance between the left edge of a control and the left edge of its parent container (screen if no parent container).
+| Value | Description |
+|-------|-------------|
+| `SpinnerSize.Tiny` | Smallest spinner, for inline use in tight spaces. |
+| `SpinnerSize.ExtraSmall` | Extra small spinner. |
+| `SpinnerSize.Small` | Small spinner. |
+| `SpinnerSize.Medium` | Medium spinner. Default. |
+| `SpinnerSize.Large` | Large spinner. |
+| `SpinnerSize.ExtraLarge` | Extra large spinner. |
+| `SpinnerSize.Huge` | Largest spinner, for full-page loading states. |
 
-**[Y](../properties-size-location.md)** – The distance between the top edge of a control and the top edge of the parent container (screen if no parent container).
+**[X](../properties-size-location.md)** – Distance between the left edge of the control and the left edge of its parent container (screen if no parent container).
 
-**Width** - The distance between a control's left and right edges. 
+**[Y](../properties-size-location.md)** – Distance between the top edge of the control and the top edge of its parent container (screen if no parent container).
 
-**Height** - The distance between a control's top and bottom edges. 
+**Width** – Distance between the control's left and right edges.
+
+**Height** – Distance between the control's top and bottom edges.
 
 ## Style and theme
 
-**Appearance** – The appearance of the Spinner. Primary or Inverted. 
+**Appearance** – The appearance of the spinner. Accepts `SpinnerAppearance` enum values: `SpinnerAppearance.Primary` (default) for the app's brand colors, or `SpinnerAppearance.Inverted` for use on dark backgrounds.
 
-**BasePaletteColor** - The color palette applied to a control. This impacts all surfaces of the control that render a theme color.  
+**SpinnerColor** – The color of the animated spinner arc. An explicit value overrides the color derived from **BasePaletteColor** and **Appearance**.
 
-**Font** - The name of the family of fonts in which text appears. 
+**TrackColor** – The color of the stationary track behind the animated arc.
 
-**FontSize** - The font size of the text that appears on a control. If the value is null or zero, then the font size is driven by selected Fluent theme. 
+**BasePaletteColor** – The color palette applied to a control. This property impacts all surfaces of the control that render a theme color.
 
-**FontColor** - The color of text in a control. 
+**Font** – The name of the family of fonts in which the label appears.
 
-**FontWeight** - The weight of the text in a control: Bold, Lighter, Normal, or Semibold. 
+**Size** – The font size of the label. If the value is null or zero, the selected Fluent theme drives the font size.
 
-**FontItalic** - Whether the text in a control is italic. 
+**Color** – The color of the label text.
 
-**FontUnderline** - Whether a line appears under the text that appears on a control. 
+**FontWeight** – The weight of the label text. Accepts `FontWeight` enum values: `FontWeight.Bold`, `FontWeight.Semibold`, `FontWeight.Normal` (default), or `FontWeight.Lighter`.
 
-**FontStrikethrough** - Whether a line appears through the text that appears on a control. 
+**Italic** – Whether the label text appears in italic style.
+
+**Underline** – Whether a line appears under the label text.
+
+**Strikethrough** – Whether a line appears through the label text.
 
 ## Additional properties
 
-**DisplayMode** – Whether the control allows user input (Edit), only displays data (View), or is disabled (Disabled).
+**Tooltip** – Explanatory text that appears when the user hovers over the control.
 
-**OnChange** - Actions to perform when the user changes the value of a control.  
+**ContentLanguage** – The display language for the control content, if different from the app language.
 
+## Example
 
+The following YAML example shows a large loading spinner that appears while `varIsLoading` is `true`:
 
+```yaml
+- LoadingSpinner:
+    Control: ModernSpinner@1.0.0
+    Properties:
+      Label: ="Loading customer records..."
+      AccessibleLabel: ="Loading customer records"
+      Visible: =varIsLoading
+      SpinnerSize: =SpinnerSize.Large
+      Appearance: =SpinnerAppearance.Primary
+      LabelPosition: =LabelPosition.Below
+      Size: =14
+      FontWeight: =FontWeight.Semibold
+```
 
+Set the loading variable before and after a data operation so the spinner shows only while work is in progress:
+
+```powerfx
+Set(varIsLoading, true);
+ClearCollect(colCustomers, Customers);
+Set(varIsLoading, false)
+```
+
+## Recent updates
+
+The updated version of the **Spinner** modern control includes the following improvements and behavior changes.
+
+### Property renames
+
+The following properties are renamed. Update any formulas in your app that reference the old property names.
+
+| Previous property | New property |
+|---|---|
+| `FontSize` | `Size` |
+| `FontColor` | `Color` |
+| `FontItalic` | `Italic` |
+| `FontUnderline` | `Underline` |
+| `FontStrikethrough` | `Strikethrough` |
+
+### Bug fixes and improvements
+
+- **Updated enums**: `Appearance`, `SpinnerSize`, and `LabelPosition` now use typed Power Fx enums (`SpinnerAppearance`, `SpinnerSize`, and `LabelPosition`) instead of string values, improving IntelliSense and reducing formula errors. `FontWeight` uses the `FontWeight` enum.
+- **Tooltip support**: New `Tooltip` property shows explanatory text on hover.
+- **Spinner color control**: New `SpinnerColor` and `TrackColor` properties let you style the animated arc and its track independently of the label text.
+- **Full font control**: Font properties are now consistent with other modern controls. Use `Font`, `Size`, `Color`, `Italic`, `Underline`, and `Strikethrough`.
+
+## See also
+
+- [Modern controls overview](overview-modern-controls.md)
+- [Recent updates to modern controls](modern-control-updates.md)
+- [Progress Bar modern control](modern-control-progress-bar.md)
+- [Size and location properties](../properties-size-location.md)

--- a/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-toggle.md
+++ b/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-toggle.md
@@ -5,7 +5,7 @@ author: noazarur-microsoft
 
 ms.topic: reference
 ms.component: canvas
-ms.date: 08/03/2026
+ms.date: 08/17/2026
 ms.subservice: canvas-maker
 ms.author: yogupt
 
@@ -80,6 +80,24 @@ A toggle is a user interface element built for modern graphical user interfaces 
 **OnSelect** – Actions to perform when the user selects a control. 
 
 **OnUncheck** – Actions to perform when the value of the toggle changes to **false**. 
+
+## Example
+
+The following YAML example shows a toggle that turns a setting on or off and responds to both states:
+
+```yaml
+- NotificationsToggle:
+    Control: ModernToggle@1.0.0
+    Properties:
+      Label: ="Enable notifications"
+      Checked: =true
+      LabelPosition: =LabelPosition.Before
+      OnCheck: =Notify("Notifications enabled", NotificationType.Success)
+      OnUncheck: =Notify("Notifications turned off", NotificationType.Information)
+      Tooltip: ="Turn notifications on or off"
+```
+
+When the user turns the toggle on, its **Checked** property becomes **true** and the **OnCheck** formula runs. Turning it off runs **OnUncheck**.
 
 ## Recent updates
 

--- a/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-updates.md
+++ b/powerapps-docs/maker/canvas-apps/controls/modern-controls/modern-control-updates.md
@@ -65,6 +65,8 @@ The following table lists each control that has an updated version, with a link 
 | Slider | [Updates to Slider](modern-control-slider.md#recent-updates) | Value renamed to Default, Layout renamed to LayoutDirection, enum values for Size and LayoutDirection, new Tooltip property |
 | Toggle | [Updates to Toggle](modern-control-toggle.md#recent-updates) | FontColor renamed to Color, FontSize renamed to Size, LabelPosition uses enum values, new Tooltip property, improved sizing, read-only View mode |
 | Checkbox | [Updates to Checkbox](modern-control-checkbox.md#recent-updates) | FontColor renamed to Color, FontSize renamed to Size, new Tooltip property, read-only View mode, more reliable Checked behavior |
+| Avatar | [Updates to Avatar](modern-control-avatar.md#recent-updates) | Font property renames, Badge and Shape use enum values, FontWeight uses enum, new OnSelect and Tooltip properties, Out of office merged into Badge |
+| Spinner | [Updates to Spinner](modern-control-spinner.md#recent-updates) | Font property renames, Appearance, SpinnerSize, and LabelPosition use enum values, new Tooltip, SpinnerColor, and TrackColor properties |
 | Form | [Updates to Form](modern-control-form.md#recent-improvements) | New screen templates, red required indicator, consistent typography, display names for people fields, reliable date fields; same form model and functions as classic |
 
 ## Property changes across modern controls
@@ -77,11 +79,11 @@ For consistency across controls, many properties have new names. If your formula
 
 | Old name (Previous) | New name (New) | Affected controls |
 |---------------------|----------------|-------------------|
-| `FontColor` | `Color` | Text, Link, Info Button, Radio, Text Input, Tab List, Number Input, Date Picker, Combo Box, Button, Toggle, Checkbox |
-| `FontSize` | `Size` | Text, Link, Info Button, Radio, Text Input, Tab List, Number Input, Date Picker, Combo Box, Button, Dropdown, Toggle, Checkbox |
-| `FontItalic` | `Italic` | Text, Link, Info Button, Radio, Text Input, Tab List, Date Picker, Combo Box, Button |
-| `FontStrikethrough` | `Strikethrough` | Text, Link, Info Button, Radio, Text Input, Date Picker, Combo Box, Button |
-| `FontUnderline` | `Underline` | Text, Link, Info Button, Radio, Text Input, Date Picker, Combo Box, Button |
+| `FontColor` | `Color` | Text, Link, Info Button, Radio, Text Input, Tab List, Number Input, Date Picker, Combo Box, Button, Toggle, Checkbox, Avatar, Spinner |
+| `FontSize` | `Size` | Text, Link, Info Button, Radio, Text Input, Tab List, Number Input, Date Picker, Combo Box, Button, Dropdown, Toggle, Checkbox, Avatar, Spinner |
+| `FontItalic` | `Italic` | Text, Link, Info Button, Radio, Text Input, Tab List, Date Picker, Combo Box, Button, Avatar, Spinner |
+| `FontStrikethrough` | `Strikethrough` | Text, Link, Info Button, Radio, Text Input, Date Picker, Combo Box, Button, Avatar, Spinner |
+| `FontUnderline` | `Underline` | Text, Link, Info Button, Radio, Text Input, Date Picker, Combo Box, Button, Avatar, Spinner |
 | `Weight` | `FontWeight` | Text only |
 | `BorderRadius` | `RadiusTopLeft`, `RadiusTopRight`, `RadiusBottomLeft`, `RadiusBottomRight` | All controls with borders |
 


### PR DESCRIPTION
## Summary

Updates reference documentation for four modern controls in `powerapps-docs/maker/canvas-apps/controls/modern-controls/`:

- **Avatar** (`modern-control-avatar.md`) — Modernized to match the current modern-control article template. Adds a `PresenceBadge` enum table for **Badge**, an `AvatarShape` enum for **Shape**, **OnSelect** behavior (interactive/button semantics plus keyboard accessibility), a `FontWeight` enum, the standard font-property renames (`FontSize`→`Size`, `FontColor`→`Color`, `FontItalic`→`Italic`, `FontUnderline`→`Underline`, `FontStrikethrough`→`Strikethrough`), a **Tooltip** property, an **Example**, and a **Recent updates** section.
- **Spinner** (`modern-control-spinner.md`) — Modernized similarly. Turns **Appearance** (`SpinnerAppearance`), **SpinnerSize** (`SpinnerSize`), and **LabelPosition** (`LabelPosition`) into typed enums; adds `SpinnerColor`/`TrackColor`, **Tooltip**, the font renames, an **Example**, and a **Recent updates** section.
- **Toggle** (`modern-control-toggle.md`) — Adds an **Example** section and bumps `ms.date`. (Property content was already modernized upstream.)
- **Checkbox** (`modern-control-checkbox.md`) — Adds an **Example** section and bumps `ms.date`. (Property content was already modernized upstream.)
- **Updates index** (`modern-control-updates.md`) — Adds Avatar and Spinner to the "controls with available updates" table and to the cross-control property-rename tables.

## Please verify before publishing

- **Avatar `Appearance`**: kept the shipped values **Brand / Neutral / Colorful**. A separate design spec referenced a larger `AvatarColor` enum; I did **not** introduce it here, pending confirmation of what actually shipped.
- **Spinner `SpinnerColor` / `TrackColor`**: new property names taken from the design spec — please confirm the exact names.
- **Example control identifiers** use `Modern<Name>@1.0.0` (for example `ModernAvatar@1.0.0`, `ModernSpinner@1.0.0`) by analogy with shipped examples such as `ModernButton@1.0.0`. Please confirm the correct component versions.
- **Shipping status**: please confirm the Avatar and Spinner property updates described here have actually shipped before this article set is published.

> Draft PR — not ready for merge. Opened for review of the content and the open questions above.
