### PR TITLE
Fix variable assignment and update GH_TOKEN usage

### DIFF
--- a/.github/workflows/cascade-include-changes.yml
+++ b/.github/workflows/cascade-include-changes.yml
@@ -40,7 +40,7 @@ jobs:
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            FILES="${{ inputs.changed_files }}"
+            FILES="$CHANGED_FILES_INPUT"
             echo "Manual run — using provided file list: $FILES"
           else
             FILES=$(gh pr view "${{ github.event.pull_request.number }}" \
@@ -50,7 +50,8 @@ jobs:
           fi
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.CASCADE_PAT }}
+          CHANGED_FILES_INPUT: ${{ inputs.changed_files }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Because `CASCADE_PAT` is present in that step’s environment, injected commands can read and exfiltrate it despite GitHub’s log masking. Anyone with permission to invoke `workflow_dispatch` could exploit this.